### PR TITLE
fix: update active job geocoding.

### DIFF
--- a/cigo_wrapper/entity/Job.py
+++ b/cigo_wrapper/entity/Job.py
@@ -2,9 +2,12 @@ import json
 
 from cigo_wrapper.entity.JobGeocoding import JobGeocoding
 from cigo_wrapper.entity.JobProgress import JobProgress
+from cigo_wrapper.entity.VehicleTracking import VehicleTracking
 
 
 # All dates are in ISO-8601 format
+
+
 class Job:
     # In the documentation the create request used 'type' as the key but in the response it uses 'job_type'
     type = None
@@ -40,7 +43,8 @@ class Job:
     payment_collection = None
     review = None
 
-    def __init__(self, date, customer_first_name, customer_last_name, phone_number, address, skip_staging=True):
+    def __init__(self, date=None, customer_first_name="", customer_last_name="", phone_number="", address="",
+                 skip_staging=True):
         # Job created will skip the staging area (Import Tool) if True
         self.skip_staging = skip_staging
 
@@ -56,6 +60,25 @@ class Job:
 
     def to_json(self):
         return json.loads(json.dumps(self, default=lambda o: o.__dict__))
+
+    @classmethod
+    def from_geocoding(cls, job_response):
+        response_dic = job_response
+        job = cls()
+        for key in response_dic.keys():
+            if key == 'job_id' and response_dic[key] is not None:
+                job.job_id = response_dic[key]
+            elif key == 'status' and response_dic[key] is not None:
+                job.status = response_dic[key]
+            elif key == 'progress' and response_dic[key] is not None:
+                job.progress = JobProgress.from_json(response_dic[key])
+            elif key == 'coordinates' and response_dic[key] is not None:
+                job.coordinates = response_dic[key]  # is the location of the Job (the target location)
+            elif key == 'geocoding' and response_dic[key] is not None:
+                job.geocoding = JobGeocoding.from_json(response_dic[key])
+            elif key == 'vehicle_tracking' and response_dic[key] is not None:
+                job.vehicle_tracking = VehicleTracking.from_json(response_dic[key])
+        return job
 
     @classmethod
     def from_json(cls, job_response):

--- a/cigo_wrapper/entity/JobGeocoding.py
+++ b/cigo_wrapper/entity/JobGeocoding.py
@@ -1,18 +1,24 @@
+import json
+
+
 class JobGeocoding:
     validity = None
     subdivision_code = None
     country_code = None
 
+    def to_json(self):
+        return json.loads(json.dumps(self, default=lambda o: o.__dict__))
+
     @classmethod
     def from_json(cls, job_response):
         geocoding = cls()
-        response_dic = job_response
-        for key in response_dic.keys():
-            if key == 'validity' and response_dic[key] is not None:
-                geocoding.validity = response_dic[key]
-            elif key == 'subdivision_code' and response_dic[key] is not None:
-                geocoding.subdivision_code = response_dic[key]
-            elif key == 'country_code' and response_dic[key] is not None:
-                geocoding.country_code = response_dic[key]
+        response = job_response
+        for key in response.keys():
+            if key == 'validity' and response[key] is not None:
+                geocoding.validity = response[key]
+            elif key == 'subdivision_code' and response[key] is not None:
+                geocoding.subdivision_code = response[key]
+            elif key == 'country_code' and response[key] is not None:
+                geocoding.country_code = response[key]
 
         return geocoding

--- a/cigo_wrapper/entity/JobProgress.py
+++ b/cigo_wrapper/entity/JobProgress.py
@@ -1,3 +1,6 @@
+import json
+
+
 class JobProgress:
     duration = None
     start_datetime = None
@@ -5,20 +8,23 @@ class JobProgress:
     started = None
     finished = None
 
+    def to_json(self):
+        return json.loads(json.dumps(self, default=lambda o: o.__dict__))
+
     @classmethod
     def from_json(cls, job_response):
         progress = cls()
-        response_dic = job_response
-        for key in response_dic.keys():
-            if key == 'duration' and response_dic[key] is not None:
-                progress.duration = response_dic[key]
-            elif key == 'start_datetime' and response_dic[key] is not None:
-                progress.start_datetime = response_dic[key]
-            elif key == 'end_datetime' and response_dic[key] is not None:
-                progress.end_datetime = response_dic[key]
-            elif key == 'started' and response_dic[key] is not None:
-                progress.started = response_dic[key]
-            elif key == 'finished' and response_dic[key] is not None:
-                progress.finished = response_dic[key]
+        response = job_response
+        for key in response.keys():
+            if key == 'duration' and response[key] is not None:
+                progress.duration = response[key]
+            elif key == 'start_datetime' and response[key] is not None:
+                progress.start_datetime = response[key]
+            elif key == 'end_datetime' and response[key] is not None:
+                progress.end_datetime = response[key]
+            elif key == 'started' and response[key] is not None:
+                progress.started = response[key]
+            elif key == 'finished' and response[key] is not None:
+                progress.finished = response[key]
 
         return progress

--- a/cigo_wrapper/entity/JobRoute.py
+++ b/cigo_wrapper/entity/JobRoute.py
@@ -1,0 +1,24 @@
+import json
+
+
+class JobRoute:
+    arrival_time = None
+    distance = None
+    road_time = None
+
+    def to_json(self):
+        return json.loads(json.dumps(self, default=lambda o: o.__dict__))
+
+    @classmethod
+    def from_json(cls, job_response):
+        route = cls()
+        response = job_response
+        for key in response.keys():
+            if key == 'arrival_time' and response[key] is not None:
+                route.arrival_time = response[key]
+            elif key == 'distance' and response[key] is not None:
+                route.distance = response[key]
+            elif key == 'road_time' and response[key] is not None:
+                route.road_time = response[key]
+
+        return route

--- a/cigo_wrapper/entity/VehicleTracking.py
+++ b/cigo_wrapper/entity/VehicleTracking.py
@@ -1,4 +1,5 @@
 class VehicleTracking:
+    # it is the last known location for the vehicle assigned to fulfil this job
     coordinates = None
     last_known = None
     route_data = None

--- a/cigo_wrapper/entity/VehicleTracking.py
+++ b/cigo_wrapper/entity/VehicleTracking.py
@@ -1,19 +1,27 @@
+import json
+
+from cigo_wrapper.entity.JobRoute import JobRoute
+
+
 class VehicleTracking:
     # it is the last known location for the vehicle assigned to fulfil this job
     coordinates = None
     last_known = None
     route_data = None
 
+    def to_json(self):
+        return json.loads(json.dumps(self, default=lambda o: o.__dict__))
+
     @classmethod
     def from_json(cls, job_response):
         vehicle_tracking = cls()
-        response_dic = job_response
-        for key in response_dic.keys():
-            if key == 'coordinates' and response_dic[key] is not None:
-                vehicle_tracking.coordinates = response_dic[key]
-            elif key == 'last_known' and response_dic[key] is not None:
-                vehicle_tracking.last_known = response_dic[key]
-            elif key == 'route_data' and response_dic[key] is not None:
-                vehicle_tracking.route_data = response_dic[key]
+        response = job_response
+        for key in response.keys():
+            if key == 'coordinates' and response[key] is not None:
+                vehicle_tracking.coordinates = response[key]
+            elif key == 'last_known' and response[key] is not None:
+                vehicle_tracking.last_known = response[key]
+            elif key == 'route_data' and response[key] is not None:
+                vehicle_tracking.route_data = JobRoute.from_json(response[key])
 
         return vehicle_tracking

--- a/cigo_wrapper/network/CigoConnect.py
+++ b/cigo_wrapper/network/CigoConnect.py
@@ -3,9 +3,6 @@ import requests
 from cigo_wrapper.entity.Itinerary import Itinerary
 from cigo_wrapper.entity.Job import Job
 from cigo_wrapper.entity.JobAction import JobAction
-from cigo_wrapper.entity.JobGeocoding import JobGeocoding
-from cigo_wrapper.entity.JobProgress import JobProgress
-from cigo_wrapper.entity.VehicleTracking import VehicleTracking
 
 
 class CigoConnect:
@@ -196,23 +193,7 @@ class CigoConnect:
         if data['statusCode'] != 200:
             return self.__raise_response_exception(response)
 
-        job_data = data["job"]
-        job = Job.from_json(job_data)
-
-        # In job the job instance "coordinates", "progress" and "geocoding" are added from response.post_staging.%,
-        # but in retrieve_job_latest_geolocation we are getting coordinates under response.%
-        if job_data.get("progress"):
-            job.progress = JobProgress.from_json(job_data["progress"])
-
-        if job_data.get("coordinates"):
-            job.coordinates = job_data["coordinates"]
-
-        if job_data.get("geocoding"):
-            job.geocoding = JobGeocoding.from_json(job_data["geocoding"])
-
-        if job_data.get("vehicle_tracking"):
-            job.vehicle_tracking = VehicleTracking.from_json(job_data["vehicle_tracking"])
-        return job
+        return Job.from_geocoding(data["job"])
 
     def __raise_response_exception(self, response):
         raise Exception('{}'.format(response.json()))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+
+setup(
+    name='Cigo-API-Library',
+    version='0.1.0',
+    packages=['cigo_wrapper', 'cigo_wrapper.entity', 'cigo_wrapper.network'],
+    url='',
+    license='MIT License',
+    author='Abdullah',
+    author_email='abdullah@joincoded.com',
+    description='Python Cigo Wrapper'
+)


### PR DESCRIPTION
[RH-965](https://shopraha.atlassian.net/browse/RH-965)
Job geocoding response is different than the regular retrieve job response. in order to get around this, this PR adds a new function `from_geocoding` to initiate the job object.

Also adding `setup.py` file, the presence of which will give an indication while installing that this package has likely been packaged and distributed with Distutils, which is the standard for distributing Python Modules.

This allows you to easily install Python packages. Often it's enough to write:

`$ pip install .`

pip will use setup.py to install your module. Avoid calling setup.py directly.

https://docs.python.org/3/installing/index.html#installing-index