### PR TITLE
fix(job-actions): Update job actions should not contain job type

### DIFF
--- a/cigo_wrapper/entity/JobAction.py
+++ b/cigo_wrapper/entity/JobAction.py
@@ -25,8 +25,9 @@ class JobAction:
     shipping_barcode = None
     create_datetime = None
 
-    def __init__(self, ref_id, description):
+    def __init__(self, ref_id, action_type, description):
         self.id = ref_id
+        self.type = action_type
         self.description = description
 
     def to_json(self):
@@ -35,7 +36,11 @@ class JobAction:
     @classmethod
     def from_json(cls, action_response):
         response_dic = action_response
-        action = cls(ref_id=response_dic['id'], description=response_dic['description'])
+        action = cls(
+            ref_id=response_dic['id'],
+            description=response_dic['description'],
+            action_type=response_dic['type'],
+        )
 
         for key in response_dic.keys():
             if key == 'action_id' and response_dic[key] is not None:

--- a/cigo_wrapper/network/CigoConnect.py
+++ b/cigo_wrapper/network/CigoConnect.py
@@ -140,10 +140,13 @@ class CigoConnect:
 
     def update_a_job_action(self, job_id, action_id, action):
         """get a job_id, action_id and return -> json response"""
-
+        data = action.to_json()
+        __ = data.pop("type", None)
         response = requests.patch(
-            self.base_url.format('jobs/id/{job_id}/actions/{action_id}').format(job_id=job_id, action_id=action_id),
-            auth=(self.account_id, self.auth_key), json=action.to_json())
+            url=self.base_url.format('jobs/id/{job_id}/actions/{action_id}').format(job_id=job_id, action_id=action_id),
+            auth=(self.account_id, self.auth_key),
+            json=data,
+        )
 
         return response
 


### PR DESCRIPTION
## [RH-2146](https://shopraha.atlassian.net/browse/RH-2146): Update cigo update job actions call

After meeting with CIGO team, it is revealed that the update job actions job shouldn't pass "type" as their data argument. Due to this reason, all the job action update calls are failing. 

I am adding back the "action_type" back https://github.com/CODED-Factory/Cigo-API-Library/pull/7 because it is needed
1. create job actions
2. retrieve job (which in return also load the job actions). 